### PR TITLE
Allows include? to accept a string

### DIFF
--- a/lib/ipaddress_2/ipv4.rb
+++ b/lib/ipaddress_2/ipv4.rb
@@ -640,7 +640,7 @@ module IPAddress;
     #
     # Checks whether a subnet includes the given IP address.
     #
-    # Accepts an IPAddress::IPv4 object.
+    # Accepts an IPAddress::IPv4 object or a string.
     #
     #   ip = IPAddress("192.168.10.100/24")
     #
@@ -652,7 +652,13 @@ module IPAddress;
     #   ip.include? IPAddress("172.16.0.48/16")
     #     #=> false
     #
+    #   ip.include? "192.168.10.50"
+    #     #=> true
+    #
     def include?(oth)
+      unless oth.is_a? IPAddress::IPv4
+        oth = IPv4.new(oth)
+      end
       @prefix <= oth.prefix and network_u32 == (oth.to_u32 & @prefix.to_u32)
     end
 

--- a/lib/ipaddress_2/ipv6.rb
+++ b/lib/ipaddress_2/ipv6.rb
@@ -612,7 +612,13 @@ module IPAddress;
     #   ip6.include? IPAddress("2001:db8:1::8:800:200c:417a/76")
     #     #=> false
     #
+    #   ip6.include? "2001:db8::8:800:200c:1"
+    #     #=> true
+    #
     def include?(oth)
+      unless oth.is_a? IPAddress::IPv6
+        oth = IPv6.new(oth)
+      end
       @prefix <= oth.prefix and network_u128 == self.class.new(oth.address+"/#@prefix").network_u128
     end
 

--- a/test/ipaddress_2/ipv4_test.rb
+++ b/test/ipaddress_2/ipv4_test.rb
@@ -327,7 +327,10 @@ class IPv4Test < Minitest::Test
     assert_equal false, ip.include?(@klass.new("5.5.5.5/32"))
     assert_equal false, ip.include?(@klass.new("11.0.0.0/8"))
     ip = @klass.new("13.13.0.0/13")
-    assert_equal false, ip.include?(@klass.new("13.16.0.0/32"))    
+    assert_equal false, ip.include?(@klass.new("13.16.0.0/32"))
+    ip = @klass.new("10.10.10.0/24")
+    assert_equal true, ip.include?("10.10.10.100")
+    assert_equal false, ip.include?("10.10.9.100")
   end
 
   def test_method_include_all?

--- a/test/ipaddress_2/ipv6_test.rb
+++ b/test/ipaddress_2/ipv6_test.rb
@@ -352,6 +352,9 @@ class IPv6Test < Minitest::Test
     not_included = @klass.new "2001:db8:1::8:800:200c:417a/76"
     assert_equal true, @ip.include?(included)
     assert_equal false, @ip.include?(not_included)
+    # string test
+    assert_equal true, @ip.include?("2001:db8::8:800:200c:2")
+    assert_equal false, @ip.include?("2001:db8:1::8:800:200c:417a")
   end
 
   def test_method_include_all?


### PR DESCRIPTION
Proposing what I hope is a minor change to allow the `include?` method to accept a string. This is a compatibility request for use in Rails when replacing the default class used by Postgres for process cidr values.